### PR TITLE
Async ConnectionStrategy.close_connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This is a generic, high-throughput, optionally-burstable pool for asyncio.
 
 Some cool features:
 
-- No locking aside from the GIL; no `asyncio.Lock` or `asyncio.Condition` needs
-  to be taken in order to get a connection.
+- No locking[^1]; no `asyncio.Lock` or `asyncio.Condition` needs to be taken in
+  order to get a connection.
 - Available connections are retrieved without yielding to the event loop.
 - When `burst_limit` is specified, `max_size` acts as a "soft" limit; the pool
   can go beyond this limit to handle increased load, and shrinks back down
@@ -20,6 +20,10 @@ Some cool features:
 - The contents of the pool can be anything; just implement a
   `ConnectionStrategy`.
 
+[^1]: Theoretically, there is an implicit "lock" that is held while an asyncio
+      task is executing. No other task can execute until the current task
+      yields (since it's cooperative multitasking), so any operations during
+      that time are atomic.
 
 ## Why?
 

--- a/README.md
+++ b/README.md
@@ -107,18 +107,15 @@ exception is suppressed unless it is not a `BaseException`, like
 implementation to avoid leaking a connection in this case.
 
 
-#### `def close_connection(self, conn: Conn)`
+#### `async def close_connection(self, conn: Conn)`
 
 This method is called to close a connection. This occurs when the pool has
 exceeded `max_size` (i.e. it is bursting) and a connection is returned that is
 no longer needed (i.e. there are no more consumers waiting for a connection).
 
-Note that this method is synchronous; if closing a connection is an
-asynchronous operation, `asyncio.create_task` can be used.
-
-If this method raises an exception, the connection is dropped and the exception
-bubbles to the caller of `ConnectionPool.get_connection().__aexit__` (usually
-an `async with` block).
+If this method raises an exception, the connection is assumed to be closed and
+the exception bubbles to the caller of `ConnectionPool.get_connection().__aexit__`
+(usually an `async with` block).
 
 
 ## Integrations  with 3rd-party libraries

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ an `async with` block).
 ## Integrations  with 3rd-party libraries
 
 This package includes support for [`ddtrace`][ddtrace]/[`datadog`][datadog] and
-for [`aioredis`][aioredis].
+for [`aioredis`][aioredis] (<2.0.0).
 
 [ddtrace]: https://github.com/datadog/dd-trace-py
 [datadog]: https://github.com/datadog/datadogpy

--- a/asyncio_connection_pool/__init__.py
+++ b/asyncio_connection_pool/__init__.py
@@ -18,7 +18,7 @@ class ConnectionStrategy(ABC, Generic[Conn]):
         ...
 
     @abstractmethod
-    async def close_connection(self, conn: Conn) -> Awaitable[None]:
+    async def close_connection(self, conn: Conn) -> None:
         ...
 
 

--- a/asyncio_connection_pool/contrib/aioredis.py
+++ b/asyncio_connection_pool/contrib/aioredis.py
@@ -15,5 +15,6 @@ class RedisConnectionStrategy(ConnectionStrategy[aioredis.Redis]):  # type: igno
     def connection_is_closed(self, conn):
         return conn.closed
 
-    def close_connection(self, conn):
+    async def close_connection(self, conn):
         conn.close()
+        await conn.wait_closed()

--- a/test/test_pool.py
+++ b/test/test_pool.py
@@ -15,7 +15,7 @@ def pool_cls(request):
     return request.param
 
 
-class RandomIntStrategy(ConnectionStrategy):
+class RandomIntStrategy(ConnectionStrategy[int]):
     async def make_connection(self):
         import random
 
@@ -97,7 +97,7 @@ async def test_currently_allocating(pool_cls):
 
     ev = asyncio.Event()
 
-    class WaitStrategy(ConnectionStrategy):
+    class WaitStrategy(ConnectionStrategy[None]):
         async def make_connection(self):
             await ev.wait()
 
@@ -214,7 +214,7 @@ async def test_stale_connections(pool_cls):
 
     stale_connections = {1, 2, 3, 4}
 
-    class Strategy(ConnectionStrategy):
+    class Strategy(ConnectionStrategy[int]):
         def __init__(self):
             from itertools import count
 
@@ -254,7 +254,7 @@ async def test_stale_connections(pool_cls):
 async def test_handling_cancellederror():
     making_connection = asyncio.Event()
 
-    class Strategy(ConnectionStrategy):
+    class Strategy(ConnectionStrategy[int]):
         async def make_connection(self):
             making_connection.set()
             await asyncio.Event().wait()  # wait forever

--- a/test/test_pool.py
+++ b/test/test_pool.py
@@ -62,9 +62,7 @@ class Counter:
 
 @pytest.mark.asyncio
 async def test_concurrent_get_connection(pool_cls):
-    """Test handling several connection requests in a short time. (Not truly
-    concurrent because of the GIL)
-    """
+    """Test handling several connection requests in a short time."""
 
     pool = pool_cls(strategy=RandomIntStrategy(), max_size=20)
     nworkers = 10


### PR DESCRIPTION
This is needed in most cases to ensure that the connection is actually closed before updating the number of used connections in the pool.

To maintain backward-compatibility there is a compatibility layer, so non-async `close_connection` methods will continue to work.

Fixes #2 

---

This involves some changes to the logic for returning a connection to the pool. The number of connections that are pending closure is stored on the class instance for calculating if the connection should be closed or returned to the pool.