### PR TITLE
Fix reporting burst limit reached when it was not

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -25,7 +25,7 @@ venv = Venv(
             },
         ),
         Venv(
-            pkgs={"black": "==20.8b1"},
+            pkgs={"black": "==22.3.0"},
             venvs=[
                 Venv(
                     name="fmt",


### PR DESCRIPTION
Not sure what the exact intent was with the old code, but it seems like it was reporting that the burst limit was reached every time the pool _stopped_ bursting 🤔 

After these changes it should work as expected, and it will only create the event once per time the pool is bursting.