### PR TITLE
Declear supports Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     author_email="775.pg.12@gmail.com",
     classifiers=[
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
It works fine in Python 3.7. All tests are passed under 3.7.13.